### PR TITLE
Add cache for rotation gates

### DIFF
--- a/quri_parts/cuquantum/custatevec/sampler.py
+++ b/quri_parts/cuquantum/custatevec/sampler.py
@@ -69,7 +69,9 @@ def _sample(
     print_VRAM_usage()
 
     qubit_count = circuit.qubit_count
-    sv = cp.array([1.0] + [0.0] * (2**qubit_count - 1), dtype=precision)
+    # sv = cp.array([1.0] + [0.0] * (2**qubit_count - 1), dtype=precision)
+    sv = cp.zeros(2**qubit_count, dtype=precision)
+    sv[0] = 1.0
     res_bits = np.empty((shots,), dtype=np.int64)
     bit_ordering = np.arange(qubit_count, dtype=np.int32)
 

--- a/quri_parts/cuquantum/custatevec/sampler.py
+++ b/quri_parts/cuquantum/custatevec/sampler.py
@@ -37,6 +37,14 @@ for gate_name in gate_map.keys():
     gates_to_cache.add(gate_name)
 
 
+def print_VRAM_usage():
+    mem_info = cp.cuda.runtime.memGetInfo()
+    free_mem, total_mem = mem_info
+
+    print(f"Free memory: {free_mem / (1024**2):.2f} MB")
+    print(f"Total memory: {total_mem / (1024**2):.2f} MB")
+
+
 def _sample(
     circuit: NonParametricQuantumCircuit,
     shots: int,
@@ -57,6 +65,8 @@ def _sample(
     else:
         cuda_d_type = cuquantum.cudaDataType.CUDA_C_64F
         cuda_c_type = cuquantum.ComputeType.COMPUTE_64F
+
+    print_VRAM_usage()
 
     qubit_count = circuit.qubit_count
     sv = cp.array([1.0] + [0.0] * (2**qubit_count - 1), dtype=precision)
@@ -151,12 +161,17 @@ def _sample(
         shots,
         cuquantum.custatevec.SamplerOutput.RANDNUM_ORDER,
     )
+    print_VRAM_usage()
+    RZ_cache_size = sum([mat.nbytes for mat in rot_mat_dict["RZ"].values()])
+    print(f"{RZ_cache_size / (1024**2)} MB")
 
     # destroy sampler
     cuquantum.custatevec.sampler_destroy(sampler)
 
     # destroy handle
     cuquantum.custatevec.destroy(handle)
+
+    print_VRAM_usage()
 
     return Counter(res_bits)
 

--- a/quri_parts/cuquantum/custatevec/sampler.py
+++ b/quri_parts/cuquantum/custatevec/sampler.py
@@ -82,6 +82,10 @@ def _sample(
     circuit = transpiler(circuit)
 
     mat_dict = {}
+    rot_gate_to_cache = set(["RX", "RY", "RZ", "U1", "U2", "U3"])
+    rot_mat_dict = {}
+    for rot_gate in rot_gate_to_cache:
+        rot_mat_dict[rot_gate] = {}
 
     handle = cuquantum.custatevec.create()
     for g in circuit.gates:
@@ -93,6 +97,12 @@ def _sample(
                 mat_dict[g.name] = mat
             else:
                 mat = mat_dict[g.name]
+        elif g.name in rot_gate_to_cache:
+            if g.params not in rot_mat_dict[g.name]:
+                mat = cp.array(gate_array(g), dtype=precision)
+                rot_mat_dict[g.name][g.params] = mat
+            else:
+                mat = rot_mat_dict[g.name][g.params]
         else:
             mat = cp.array(gate_array(g), dtype=precision)
         mat_ptr = mat.data.ptr


### PR DESCRIPTION
This PR reduces the execution time of H2 Trotter QPE (14 qubits) from 7.6 sec in https://github.com/QunaSys/quri-parts-cuquantum/pull/6 to 3.9 sec by adding caches for rotation gate matrices and numpy array of target/control qubits.
Same changes for estimator and simulator are to be added.