### PR TITLE
Add standard Python ignore patterns to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,37 @@
+# Byte-compiled / cache
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+build/
+dist/
+*.egg-info/
+*.egg
+
+# Poetry (lock file is intentionally not committed)
+poetry.lock
+
+# Virtual environments
+.venv/
+venv/
+env/
+
+# Test / coverage
+.pytest_cache/
+.coverage
+.coverage.*
+htmlcov/
+coverage.xml
+
+# Type checking / linting caches
+.mypy_cache/
+.ruff_cache/
+
+# Editors / IDE
+.vscode/
+.idea/
+*.swp
+
+# OS
 .DS_Store


### PR DESCRIPTION
## Issue

N/A

## Changes

Changes proposed in this pull-request

- Add standard Python ignore patterns to `.gitignore` (previously it only contained `.DS_Store`)
  - Byte-compiled caches (`__pycache__/`, `*.py[cod]`)
  - Packaging artifacts (`build/`, `dist/`, `*.egg-info/`)
  - `poetry.lock`, which is intentionally not committed in this repo (see 79e3d5d)
  - Virtual environments, test/coverage outputs, mypy/ruff caches
  - Editor and OS files (`.vscode/`, `.idea/`, `.swp`, `.DS_Store`)

## Progress

- [x] Main implementation written
- [x] Functions as intended (`__pycache__/` directories no longer appear in `git status`)
- [ ] Unit tests have been written (N/A: no code changes)
- [ ] readme.md has been updated (N/A: no behavior changes)
